### PR TITLE
Add support for more SQL (in, group by, and order)

### DIFF
--- a/lib/dbElements.tsx
+++ b/lib/dbElements.tsx
@@ -10,6 +10,11 @@ type ClauseProps = {
   clause: string;
 };
 
+type InClauseProps = {
+  column: string;
+  items: string[];
+};
+
 type SortProps = {
   column: string;
   order: "asc" | "desc";
@@ -17,6 +22,16 @@ type SortProps = {
 
 type LimitProps = {
   value: number;
+};
+
+type OrderProps = {
+  by: string;
+  asc?: boolean;
+  desc?: boolean;
+};
+
+type GroupProps = {
+  by: string;
 };
 
 function Select(
@@ -36,12 +51,33 @@ function Clause({ clause }: ClauseProps): string {
   return `${clause}`;
 }
 
+/**
+ * Builds an "IN" clause like `column in ('a', 'b', 'c')`
+ */
+function InClause({ column, items }: InClauseProps): string {
+  return `${column} in (${items.map((i) => `'${i}'`).join(",")})`;
+}
+
 function Sort({ column, order }: SortProps): string {
   return ` SORT BY ${column} ${order}`;
 }
 
 function Limit({ value }: LimitProps): string {
   return ` LIMIT ${value}`;
+}
+
+/**
+ * Builds an "ORDER" statement like `ORDER BY column asc`
+ */
+function Order({ by, asc, desc }: OrderProps): string {
+  return ` ORDER BY ${by} ${asc ? "asc" : ""}${desc ? "desc" : ""}`;
+}
+
+/**
+ * Builds a "GROUP" statement like `GROUP BY column asc`
+ */
+function Group({ by }: GroupProps): string {
+  return ` GROUP BY ${by}`;
 }
 
 export function createElement(
@@ -52,4 +88,4 @@ export function createElement(
   return type(props, children);
 }
 
-export { Select, Where, Clause, Sort, Limit };
+export { Select, Where, Clause, InClause, Sort, Limit, Group, Order };


### PR DESCRIPTION
Hi!

I found this really useful at work, we're moving to a new database and so upgrading our querying technology just makes sense!

Some of the queries I'm writing unfortunately weren't possible using jsqx, so I thought I'd contribute back my additions.

This adds an `in` clause, as well as `order by` and `group by`.

You can use it like:

```jsx
const uuids = [
  "45235f81-8b30-454e-b5c5-31cbe4b46045",
  "df523159-9a17-4b9b-9b81-60f91120ca2f",
];

const query = (
  <Select
    table="some_table"
    columns={["uuid", "order", "value"]}
  >
    <Where>
      <InClause column="uuid" items={uuids} />
    </Where>
    <Order by="order" desc />
    <Group by="value" />
  </Select>
);
```